### PR TITLE
extraction: clearer default label policies

### DIFF
--- a/src/edu/jhu/thrax/util/BackwardsCompatibility.java
+++ b/src/edu/jhu/thrax/util/BackwardsCompatibility.java
@@ -26,4 +26,12 @@ public class BackwardsCompatibility {
 
     return features;
   }
+
+	public static String defaultLabelPolicy(boolean allow_nonlexical_x) {
+		if (allow_nonlexical_x) {
+			return "always";
+		} else {
+			return "phrases";
+		}
+	}
 }


### PR DESCRIPTION
This patch introduces the configuration key "allow-default-nt"
to let the user specify when default labels should be allowed for
extracted rules.

The possible keys are "always", "phrases", or "never", with
"always" being the default. These options correspond to the
following policies:

ALWAYS: the default NT is always allowed to be used for the LHS
or gap in any rule. (Hiero policy.)

PHRASES: the default NT is only allowed for the LHS of non-
hierarchical rules. (This is the default SAMT policy.)

NEVER: never use the default NT for any rule.

The previous configuration setting to change this policy was the
poorly named "allow-nonlexical-x". This was a boolean key, where
true meant the default NT could be used anywhere, and "false"
meant it would be disallowed for the LHS of a non-hierarchical
rule. This behavior has been kept for backward compatibility.
The mapping is thus

"allow-nonlexical-x" true => "allow-default-nt" "always"
"allow-nonlexical-x" false => "allow-default-nt" "phrases"

Previously, there was no way to set "never".
