### PR TITLE
Bugfix related to lexical probability features + correct exit code on…

### DIFF
--- a/src/edu/jhu/thrax/Thrax.java
+++ b/src/edu/jhu/thrax/Thrax.java
@@ -38,11 +38,14 @@ import edu.jhu.thrax.util.ConfFileParser;
 public class Thrax extends Configured implements Tool {
   private Scheduler scheduler;
   private Configuration conf;
+  
+  private final int RETURN_CODE_FAILED = 1;
+  private final int RETURN_CODE_SUCCESS = 0;
 
   public synchronized int run(String[] argv) throws Exception {
     if (argv.length < 1) {
       System.err.println("usage: Thrax <conf file> [output path]");
-      return 1;
+      return RETURN_CODE_FAILED;
     }
     // do some setup of configuration
     conf = getConf();
@@ -81,8 +84,10 @@ public class Thrax extends Configured implements Tool {
       System.err.println("To retrieve grammar:");
       System.err.println("hadoop fs -getmerge " + conf.get("thrax.outputPath", "")
           + " <destination>");
+      return RETURN_CODE_SUCCESS;
+    } else {
+      return RETURN_CODE_FAILED;
     }
-    return 0;
   }
 
   // Schedule all the jobs required for grammar extraction. We
@@ -166,8 +171,8 @@ public class Thrax extends Configured implements Tool {
   }
 
   public static void main(String[] argv) throws Exception {
-    ToolRunner.run(null, new Thrax(), argv);
-    return;
+    int returnCode = ToolRunner.run(null, new Thrax(), argv);
+    System.exit(returnCode);
   }
 
   protected synchronized void workerDone(Class<? extends ThraxJob> theClass, boolean success) {

--- a/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationFeatureJob.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationFeatureJob.java
@@ -16,6 +16,7 @@ import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 import edu.jhu.thrax.hadoop.datatypes.Annotation;
 import edu.jhu.thrax.hadoop.datatypes.FeaturePair;
 import edu.jhu.thrax.hadoop.datatypes.RuleWritable;
+import edu.jhu.thrax.hadoop.jobs.DefaultValues;
 import edu.jhu.thrax.hadoop.jobs.ExtractionJob;
 import edu.jhu.thrax.hadoop.jobs.ThraxJob;
 
@@ -61,7 +62,7 @@ public class AnnotationFeatureJob implements ThraxJob {
     job.setOutputValueClass(FeaturePair.class);
     job.setOutputFormatClass(SequenceFileOutputFormat.class);
 
-    int num_reducers = conf.getInt("thrax.reducers", 4);
+    int num_reducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(num_reducers);
 
     FileInputFormat.setInputPaths(job, new Path(conf.get("thrax.work-dir") + "rules"));

--- a/src/edu/jhu/thrax/hadoop/features/mapred/MapReduceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/MapReduceFeature.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.mapreduce.lib.reduce.IntSumReducer;
 import edu.jhu.thrax.hadoop.datatypes.FeaturePair;
 import edu.jhu.thrax.hadoop.datatypes.RuleWritable;
 import edu.jhu.thrax.hadoop.features.Feature;
+import edu.jhu.thrax.hadoop.jobs.DefaultValues;
 import edu.jhu.thrax.hadoop.jobs.ExtractionJob;
 import edu.jhu.thrax.hadoop.jobs.ThraxJob;
 
@@ -63,7 +64,7 @@ public abstract class MapReduceFeature implements Feature, ThraxJob {
 
     setMapOutputFormat(job);
     
-    int num_reducers = conf.getInt("thrax.reducers", 4);
+    int num_reducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(num_reducers);
 
     FileInputFormat.setInputPaths(job, new Path(conf.get("thrax.work-dir") + "rules"));

--- a/src/edu/jhu/thrax/hadoop/jobs/DefaultValues.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/DefaultValues.java
@@ -1,0 +1,7 @@
+package edu.jhu.thrax.hadoop.jobs;
+
+public class DefaultValues {
+  public static int DEFAULT_NUM_REDUCERS = 4;
+  
+  private DefaultValues() {};
+}

--- a/src/edu/jhu/thrax/hadoop/jobs/DistributionalContextExtractionJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/DistributionalContextExtractionJob.java
@@ -38,7 +38,7 @@ public class DistributionalContextExtractionJob implements ThraxJob {
 
     job.setOutputFormatClass(SequenceFileOutputFormat.class);
 
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     FileInputFormat.setInputPaths(job, new Path(conf.get("thrax.input-file")));

--- a/src/edu/jhu/thrax/hadoop/jobs/ExtractionJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/ExtractionJob.java
@@ -44,7 +44,7 @@ public class ExtractionJob implements ThraxJob {
 
     job.setOutputFormatClass(SequenceFileOutputFormat.class);
 
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     FileInputFormat.setInputPaths(job, new Path(conf.get("thrax.input-file")));

--- a/src/edu/jhu/thrax/hadoop/jobs/FeatureCollectionJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/FeatureCollectionJob.java
@@ -60,7 +60,7 @@ public class FeatureCollectionJob implements ThraxJob {
 
     job.setPartitionerClass(RuleWritable.YieldPartitioner.class);
 
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     int maxSplitSize = conf.getInt("thrax.max-split-size", 0);

--- a/src/edu/jhu/thrax/hadoop/jobs/OutputJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/OutputJob.java
@@ -56,7 +56,7 @@ public class OutputJob implements ThraxJob {
 
     // Output is always running alone, so give it as many
     // reduce tasks as possible.
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     boolean annotation_features = false;

--- a/src/edu/jhu/thrax/hadoop/jobs/ParaphraseAggregationJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/ParaphraseAggregationJob.java
@@ -47,7 +47,7 @@ public class ParaphraseAggregationJob implements ThraxJob {
     int maxSplitSize = conf.getInt("thrax.max-split-size", 0);
     if (maxSplitSize != 0) FileInputFormat.setMaxInputSplitSize(job, maxSplitSize * 20);
 
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     String outputPath = conf.get("thrax.outputPath", "");

--- a/src/edu/jhu/thrax/hadoop/jobs/ParaphrasePivotingJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/ParaphrasePivotingJob.java
@@ -52,7 +52,7 @@ public class ParaphrasePivotingJob implements ThraxJob {
     int maxSplitSize = conf.getInt("thrax.max-split-size", 0);
     if (maxSplitSize != 0) FileInputFormat.setMaxInputSplitSize(job, maxSplitSize * 20);
 
-    int numReducers = conf.getInt("thrax.reducers", 4);
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(numReducers);
 
     FileOutputFormat.setOutputPath(job, new Path(conf.get("thrax.work-dir") + "pivoted"));

--- a/src/edu/jhu/thrax/hadoop/jobs/VocabularyJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/VocabularyJob.java
@@ -51,7 +51,7 @@ public class VocabularyJob implements ThraxJob {
 
     FileOutputFormat.setOutputPath(job, new Path(conf.get("thrax.work-dir") + "vocabulary"));
 
-    int num_reducers = conf.getInt("thrax.reducers", 4);
+    int num_reducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
     job.setNumReduceTasks(num_reducers);
 
     return job;

--- a/src/edu/jhu/thrax/hadoop/jobs/WordLexprobJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/WordLexprobJob.java
@@ -43,6 +43,9 @@ public abstract class WordLexprobJob implements ThraxJob {
 
     job.setMapOutputKeyClass(LongWritable.class);
     job.setMapOutputValueClass(IntWritable.class);
+    
+    int numReducers = conf.getInt("thrax.reducers", conf.getInt("mapreduce.job.reduces", DefaultValues.DEFAULT_NUM_REDUCERS));
+    job.setNumReduceTasks(numReducers);
 
     job.setOutputKeyClass(LongWritable.class);
     job.setOutputValueClass(FloatWritable.class);

--- a/src/edu/jhu/thrax/lexprob/TrieLexprobTable.java
+++ b/src/edu/jhu/thrax/lexprob/TrieLexprobTable.java
@@ -60,6 +60,24 @@ public class TrieLexprobTable extends SequenceFileLexprobTable {
     }
     cdrs[i] = intArray(cdrList);
     values[i] = floatArray(valueList);
+    checkIntegrity();
+  }
+
+  private void checkIntegrity() {
+    for (int i = 0; i < cars.length-1; i++) {
+      if (cars[i] > cars[i+1]) {
+        final String msg = String.format("Failed loading TrieLexprobTable. Entries must be sorted ascendingly, but cars[%d]=%d > cars[%d]=%d",
+            i, cars[i], i+1, cars[i+1]);
+        throw new RuntimeException(msg);
+      }
+      for (int j = 0; j < cdrs[i].length-1; j++) {
+        if (cdrs[i][j] > cdrs[i][j+1]) {
+          final String msg = String.format("Failed loading TrieLexprobTable. Entries must be sorted ascendingly, but cdrs[%d][%d]=%d > cdrs[%d][%d]=%d",
+              i, j, cdrs[i][j], i+1, j+1, cdrs[i][j+1]);
+          throw new RuntimeException(msg);
+        }
+      }
+    }
   }
 
   private static float[] floatArray(List<Float> list) {


### PR DESCRIPTION
… failure + use number of reducers from hadoop, when set.

Details:
TrieLexprobTable consumes the output of WordLexprobJob. It expects the output to be sorted in order to use binary search later. So far this was not an issue as the default setting for the number of reducers is 1, which led to a sorted output. If the number of reducers is increased this fails however, as each reducer output is sorted, but the parts combined are not. The solution is to partition the output of WordLexprobJob so that the sorted parts combined are sorted too.