### PR TITLE
add source and target raw count features

### DIFF
--- a/src/edu/jhu/thrax/hadoop/features/mapred/MapReduceFeatureFactory.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/MapReduceFeatureFactory.java
@@ -24,6 +24,10 @@ public class MapReduceFeatureFactory {
       return new TargetPhraseGivenLHSFeature();
     else if (name.equals(LhsGivenTargetPhraseFeature.NAME))
       return new LhsGivenTargetPhraseFeature();
+    else if (name.equals(SourceCountFeature.NAME))
+      return new SourceCountFeature();
+    else if (name.equals(TargetCountFeature.NAME))
+      return new TargetCountFeature();
 
     return null;
   }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/SourceCountFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/SourceCountFeature.java
@@ -1,0 +1,149 @@
+package edu.jhu.thrax.hadoop.features.mapred;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Partitioner;
+import org.apache.hadoop.mapreduce.Reducer;
+
+import edu.jhu.thrax.hadoop.comparators.FieldComparator;
+import edu.jhu.thrax.hadoop.comparators.PrimitiveArrayMarginalComparator;
+import edu.jhu.thrax.hadoop.datatypes.Annotation;
+import edu.jhu.thrax.hadoop.datatypes.FeaturePair;
+import edu.jhu.thrax.hadoop.datatypes.PrimitiveUtils;
+import edu.jhu.thrax.hadoop.datatypes.RuleWritable;
+import edu.jhu.thrax.util.Vocabulary;
+
+@SuppressWarnings("rawtypes")
+public class SourceCountFeature extends MapReduceFeature {
+
+  public static final String NAME = "f_count";
+  public static final String LABEL = "C(f)";
+  
+  public String getName() {
+    return NAME;
+  }
+  
+  public String getLabel() {
+    return LABEL;
+  }
+
+  public Class<? extends WritableComparator> sortComparatorClass() {
+    return Comparator.class;
+  }
+
+  public Class<? extends Partitioner> partitionerClass() {
+    return RuleWritable.SourcePartitioner.class;
+  }
+
+  public Class<? extends Mapper> mapperClass() {
+    return Map.class;
+  }
+
+  public Class<? extends Reducer> reducerClass() {
+    return Reduce.class;
+  }
+
+  private static class Map extends Mapper<RuleWritable, Annotation, RuleWritable, IntWritable> {
+
+    protected void setup(Context context) throws IOException, InterruptedException {
+      Configuration conf = context.getConfiguration();
+      String vocabulary_path = conf.getRaw("thrax.work-dir") + "vocabulary/part-*";
+      Vocabulary.initialize(conf, vocabulary_path);
+    }
+
+    protected void map(RuleWritable key, Annotation value, Context context) throws IOException,
+        InterruptedException {
+
+      RuleWritable source_marginal = new RuleWritable(key);
+      source_marginal.lhs = PrimitiveUtils.MARGINAL_ID;
+      source_marginal.target = PrimitiveArrayMarginalComparator.MARGINAL;
+      source_marginal.monotone = false;
+
+      RuleWritable source_target_marginal = new RuleWritable(key);
+      source_target_marginal.lhs = PrimitiveUtils.MARGINAL_ID;
+
+      IntWritable count = new IntWritable(value.count());
+
+      context.write(source_marginal, count);
+      context.write(source_target_marginal, count);
+      context.write(key, count);
+    }
+  }
+
+  private static class Reduce extends Reducer<RuleWritable, IntWritable, RuleWritable, FeaturePair> {
+    private IntWritable sourceCount;
+
+    protected void setup(Context context) throws IOException, InterruptedException {
+      Configuration conf = context.getConfiguration();
+      String vocabulary_path = conf.getRaw("thrax.work-dir") + "vocabulary/part-*";
+      Vocabulary.initialize(conf, vocabulary_path);
+    }
+
+    protected void reduce(RuleWritable key, Iterable<IntWritable> values, Context context)
+        throws IOException, InterruptedException {
+      if (Arrays.equals(key.target, PrimitiveArrayMarginalComparator.MARGINAL)) {
+        int count = 0;
+        for (IntWritable x : values)
+          count += x.get();
+		this.sourceCount = new IntWritable(count);
+        return;
+      }
+      if (key.lhs == PrimitiveUtils.MARGINAL_ID) {
+        return;
+      }
+      context.write(key, new FeaturePair(Vocabulary.id(LABEL), sourceCount));
+    }
+
+  }
+
+  public static class Comparator extends WritableComparator {
+
+    private static final WritableComparator PARRAY_COMP = new PrimitiveArrayMarginalComparator();
+    private static final FieldComparator SOURCE_COMP = new FieldComparator(0, PARRAY_COMP);
+    private static final FieldComparator TARGET_COMP = new FieldComparator(1, PARRAY_COMP);
+
+    public Comparator() {
+      super(RuleWritable.class);
+    }
+
+    public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+      try {
+        int h1 = WritableUtils.decodeVIntSize(b1[s1 + 1]) + 1;
+        int h2 = WritableUtils.decodeVIntSize(b2[s2 + 1]) + 1;
+
+        int cmp = SOURCE_COMP.compare(b1, s1 + h1, l1 - h1, b2, s2 + h2, l2 - h2);
+        if (cmp != 0) return cmp;
+
+        cmp = TARGET_COMP.compare(b1, s1 + h1, l1 - h1, b2, s2 + h2, l2 - h2);
+        if (cmp != 0) return cmp;
+
+        cmp = PrimitiveUtils.compare(b1[s1], b2[s2]);
+        if (cmp != 0) return cmp;
+
+        int lhs1 = Math.abs(WritableComparator.readVInt(b1, s1 + 1));
+        int lhs2 = Math.abs(WritableComparator.readVInt(b2, s2 + 1));
+        return PrimitiveUtils.compare(lhs1, lhs2);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+
+  private static final FloatWritable ZERO = new FloatWritable(0.0f);
+
+  public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
+    map.put(Vocabulary.id(LABEL), ZERO);
+  }
+
+  public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
+    map.put(Vocabulary.id(LABEL), ZERO);
+  }
+}

--- a/src/edu/jhu/thrax/hadoop/features/mapred/TargetCountFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/TargetCountFeature.java
@@ -1,0 +1,148 @@
+package edu.jhu.thrax.hadoop.features.mapred;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Partitioner;
+import org.apache.hadoop.mapreduce.Reducer;
+
+import edu.jhu.thrax.hadoop.comparators.FieldComparator;
+import edu.jhu.thrax.hadoop.comparators.PrimitiveArrayMarginalComparator;
+import edu.jhu.thrax.hadoop.datatypes.Annotation;
+import edu.jhu.thrax.hadoop.datatypes.FeaturePair;
+import edu.jhu.thrax.hadoop.datatypes.PrimitiveUtils;
+import edu.jhu.thrax.hadoop.datatypes.RuleWritable;
+import edu.jhu.thrax.util.Vocabulary;
+
+@SuppressWarnings("rawtypes")
+public class TargetCountFeature extends MapReduceFeature {
+
+  public static final String NAME = "e_count";
+  public static final String LABEL = "C(e)";
+
+  public String getName() {
+    return NAME;
+  }
+
+  public String getLabel() {
+    return LABEL;
+  }
+
+  public Class<? extends WritableComparator> sortComparatorClass() {
+    return Comparator.class;
+  }
+
+  public Class<? extends Partitioner> partitionerClass() {
+    return RuleWritable.TargetPartitioner.class;
+  }
+
+  public Class<? extends Mapper> mapperClass() {
+    return Map.class;
+  }
+
+  public Class<? extends Reducer> reducerClass() {
+    return Reduce.class;
+  }
+
+  private static class Map extends Mapper<RuleWritable, Annotation, RuleWritable, IntWritable> {
+
+    protected void setup(Context context) throws IOException, InterruptedException {
+      Configuration conf = context.getConfiguration();
+      String vocabulary_path = conf.getRaw("thrax.work-dir") + "vocabulary/part-*";
+
+      Vocabulary.initialize(conf, vocabulary_path);
+    }
+
+    protected void map(RuleWritable key, Annotation value, Context context) throws IOException,
+        InterruptedException {
+      RuleWritable target_marginal = new RuleWritable(key);
+      target_marginal.lhs = PrimitiveUtils.MARGINAL_ID;
+      target_marginal.source = PrimitiveArrayMarginalComparator.MARGINAL;
+
+      RuleWritable lhs_marginal = new RuleWritable(key);
+      lhs_marginal.lhs = PrimitiveUtils.MARGINAL_ID;
+
+      IntWritable count = new IntWritable(value.count());
+
+      context.write(target_marginal, count);
+      context.write(lhs_marginal, count);
+      context.write(key, count);
+    }
+  }
+
+  private static class Reduce extends Reducer<RuleWritable, IntWritable, RuleWritable, FeaturePair> {
+    private IntWritable targetCount;
+
+    protected void setup(Context context) throws IOException, InterruptedException {
+      Configuration conf = context.getConfiguration();
+      String vocabulary_path = conf.getRaw("thrax.work-dir") + "vocabulary/part-*";
+      Vocabulary.initialize(conf, vocabulary_path);
+    }
+
+    protected void reduce(RuleWritable key, Iterable<IntWritable> values, Context context)
+        throws IOException, InterruptedException {
+      if (Arrays.equals(key.source, PrimitiveArrayMarginalComparator.MARGINAL)) {
+        int count = 0;
+        for (IntWritable x : values)
+          count += x.get();
+		targetCount = new IntWritable(count);
+        return;
+      }
+      if (key.lhs == PrimitiveUtils.MARGINAL_ID) {
+        return;
+      }
+      context.write(key, new FeaturePair(Vocabulary.id(LABEL), targetCount));
+    }
+
+  }
+
+  public static class Comparator extends WritableComparator {
+
+    private static final WritableComparator PARRAY_COMP = new PrimitiveArrayMarginalComparator();
+    private static final FieldComparator SOURCE_COMP = new FieldComparator(0, PARRAY_COMP);
+    private static final FieldComparator TARGET_COMP = new FieldComparator(1, PARRAY_COMP);
+
+    public Comparator() {
+      super(RuleWritable.class);
+    }
+
+    public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+      try {
+        int h1 = WritableUtils.decodeVIntSize(b1[s1 + 1]) + 1;
+        int h2 = WritableUtils.decodeVIntSize(b2[s2 + 1]) + 1;
+
+        int cmp = TARGET_COMP.compare(b1, s1 + h1, l1 - h1, b2, s2 + h2, l2 - h2);
+        if (cmp != 0) return cmp;
+
+        cmp = PrimitiveUtils.compare(b1[s1], b2[s2]);
+        if (cmp != 0) return cmp;
+
+        cmp = SOURCE_COMP.compare(b1, s1 + h1, l1 - h1, b2, s2 + h2, l2 - h2);
+        if (cmp != 0) return cmp;
+
+        int lhs1 = Math.abs(WritableComparator.readVInt(b1, s1 + 1));
+        int lhs2 = Math.abs(WritableComparator.readVInt(b2, s2 + 1));
+        return PrimitiveUtils.compare(lhs1, lhs2);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+
+  private static final FloatWritable ZERO = new FloatWritable(0.0f);
+
+  public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
+    map.put(Vocabulary.id(LABEL), ZERO);
+  }
+
+  public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
+    map.put(Vocabulary.id(LABEL), ZERO);
+  }
+}


### PR DESCRIPTION
THIS IS UNTESTED. I didn't even try to compile it because this computer
doesn't have ant for some reason.

This commit adds features that emit the raw counts for the source and
target side of a given rule. That is, for a rule A -> (f,e) these
features return the number of times f was seen as a source side (summed
over the entire corpus), and similarly for e.

It's a bad hack, basically just a cut-and-paste job the phrasal
probability features, which already had to calculate this sum as the
denominator of their probabilities.