### PR TITLE
Removal of feature labels

### DIFF
--- a/src/edu/jhu/thrax/hadoop/datatypes/FeatureMap.java
+++ b/src/edu/jhu/thrax/hadoop/datatypes/FeatureMap.java
@@ -60,7 +60,7 @@ public class FeatureMap implements Writable {
       int key = 0;
       Writable val = null;
       key = WritableUtils.readVInt(in);
-      if (key == Vocabulary.id(AnnotationPassthroughFeature.LABEL)) {
+      if (key == Vocabulary.id(AnnotationPassthroughFeature.NAME)) {
         val = new Annotation();
         val.readFields(in);
       } else {
@@ -76,7 +76,7 @@ public class FeatureMap implements Writable {
     WritableUtils.writeVInt(out, map.size());
     for (int key : map.keySet()) {
       WritableUtils.writeVInt(out, key);
-      if (key == Vocabulary.id(AnnotationPassthroughFeature.LABEL)) {
+      if (key == Vocabulary.id(AnnotationPassthroughFeature.NAME)) {
         ((Annotation) this.get(key)).write(out);
       } else {
         ((FloatWritable) this.get(key)).write(out);

--- a/src/edu/jhu/thrax/hadoop/features/AbstractnessFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/AbstractnessFeature.java
@@ -11,7 +11,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class AbstractnessFeature implements SimpleFeature {
   
   public static final String NAME = "abstract";
-  public static final String LABEL = "Abstract";
   
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -34,15 +33,11 @@ public class AbstractnessFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/AdjacentNonTerminalsFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/AdjacentNonTerminalsFeature.java
@@ -11,7 +11,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class AdjacentNonTerminalsFeature implements SimpleFeature {
 
   public static final String NAME = "adjacent";
-  public static final String LABEL = "Adjacent";
 
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -33,15 +32,11 @@ public class AdjacentNonTerminalsFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/CharacterCompressionRatioFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/CharacterCompressionRatioFeature.java
@@ -12,8 +12,7 @@ public class CharacterCompressionRatioFeature implements SimpleFeature {
 
   private static final FloatWritable ZERO = new FloatWritable(0f);
 
-  public static final String NAME = "char-cr";
-  public static final String LABEL = "CharLogCR";
+  public static final String NAME = "char_cr";
   
   public Writable score(RuleWritable r) {
     int src_length = 0;
@@ -42,15 +41,11 @@ public class CharacterCompressionRatioFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/CharacterCountDifferenceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/CharacterCountDifferenceFeature.java
@@ -12,8 +12,7 @@ public class CharacterCountDifferenceFeature implements SimpleFeature {
 
   private static final IntWritable ZERO = new IntWritable(0);
 
-  public static final String NAME = "char-count-difference";
-  public static final String LABEL = "CharCountDiff";
+  public static final String NAME = "char_count_difference";
   
   public Writable score(RuleWritable r) {
     int char_difference = 0;
@@ -37,15 +36,11 @@ public class CharacterCountDifferenceFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/ConsumeSourceTerminalsFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/ConsumeSourceTerminalsFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class ConsumeSourceTerminalsFeature implements SimpleFeature {
 
-  public static final String NAME = "source-terminals-without-target";
-  public static final String LABEL = "SourceTerminalsButNoTarget";
+  public static final String NAME = "source_terminals_without_target";
   
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -34,15 +33,11 @@ public class ConsumeSourceTerminalsFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/Feature.java
+++ b/src/edu/jhu/thrax/hadoop/features/Feature.java
@@ -8,8 +8,6 @@ public interface Feature {
   
   public String getName();
   
-  public String getLabel();
-  
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map);
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map);

--- a/src/edu/jhu/thrax/hadoop/features/GlueRuleFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/GlueRuleFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class GlueRuleFeature implements SimpleFeature {
 
-  public static final String NAME = "glue-rule";
-  public static final String LABEL = "GlueRule";
+  public static final String NAME = "glue_rule";
   
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -24,15 +23,11 @@ public class GlueRuleFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/IdentityFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/IdentityFeature.java
@@ -12,7 +12,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class IdentityFeature implements SimpleFeature {
 
   public static final String NAME = "identity";
-  public static final String LABEL = "Identity";
   
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -28,15 +27,11 @@ public class IdentityFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/LexicalityFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/LexicalityFeature.java
@@ -11,7 +11,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class LexicalityFeature implements SimpleFeature {
 
   public static final String NAME = "lexical";
-  public static final String LABEL = "Lexical";
 
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -28,15 +27,11 @@ public class LexicalityFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/MonotonicFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/MonotonicFeature.java
@@ -11,7 +11,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class MonotonicFeature implements SimpleFeature {
 
   public static final String NAME = "monotonic";
-  public static final String LABEL = "Monotonic";
 
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -24,15 +23,11 @@ public class MonotonicFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/PhrasePenaltyFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/PhrasePenaltyFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class PhrasePenaltyFeature implements SimpleFeature {
 
-  public static final String NAME = "phrase-penalty";
-  public static final String LABEL = "PhrasePenalty";
+  public static final String NAME = "phrase_penalty";
 
   private static final IntWritable ONE = new IntWritable(1);
 
@@ -23,15 +22,11 @@ public class PhrasePenaltyFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE);
+    map.put(Vocabulary.id(NAME), ONE);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/ProduceTargetTerminalsFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/ProduceTargetTerminalsFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class ProduceTargetTerminalsFeature implements SimpleFeature {
 
-  public static final String NAME = "target-terminals-without-source";
-  public static final String LABEL = "TargetTerminalsButNoSource";
+  public static final String NAME = "target_terminals_without_source";
 
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -28,15 +27,11 @@ public class ProduceTargetTerminalsFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/SourceWordCounterFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/SourceWordCounterFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class SourceWordCounterFeature implements SimpleFeature {
 
-  public static final String NAME = "source-word-count";
-  private static final String LABEL = "SourceWords";
+  public static final String NAME = "source_word_count";
 
   private static final IntWritable ZERO = new IntWritable(0);
 
@@ -26,15 +25,11 @@ public class SourceWordCounterFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/TargetWordCounterFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/TargetWordCounterFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class TargetWordCounterFeature implements SimpleFeature {
 
-  public static final String NAME = "target-word-count";
-  public static final String LABEL = "TargetWords";
+  public static final String NAME = "target_word_count";
 
   private static final IntWritable ZERO = new IntWritable(0);
 
@@ -26,15 +25,11 @@ public class TargetWordCounterFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/WordCompressionRatioFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/WordCompressionRatioFeature.java
@@ -11,8 +11,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class WordCompressionRatioFeature implements SimpleFeature {
 
-  public static final String NAME = "word-cr";
-  public static final String LABEL = "WordLogCR";
+  public static final String NAME = "word_cr";
 
   private static final IntWritable ZERO = new IntWritable(0);
 
@@ -34,15 +33,11 @@ public class WordCompressionRatioFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/WordCountDifferenceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/WordCountDifferenceFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class WordCountDifferenceFeature implements SimpleFeature {
 
-  public static final String NAME = "word-count-difference";
-  public static final String LABEL = "WordCountDiff";
+  public static final String NAME = "word_count_difference";
 
   private static final IntWritable ZERO = new IntWritable(0);
 
@@ -28,15 +27,11 @@ public class WordCountDifferenceFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/WordLengthDifferenceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/WordLengthDifferenceFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class WordLengthDifferenceFeature implements SimpleFeature {
 
-  public static final String NAME = "word-length-difference";
-  public static final String LABEL = "WordLenDiff";
+  public static final String NAME = "word_length_difference";
 
   private static final FloatWritable ZERO = new FloatWritable(0);
 
@@ -45,15 +44,11 @@ public class WordLengthDifferenceFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/XRuleFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/XRuleFeature.java
@@ -10,8 +10,7 @@ import edu.jhu.thrax.util.Vocabulary;
 
 public class XRuleFeature implements SimpleFeature {
 
-  public static final String NAME = "x-rule";
-  public static final String LABEL = "ContainsX";
+  public static final String NAME = "x_rule";
 
   private static final IntWritable ZERO = new IntWritable(0);
   private static final IntWritable ONE = new IntWritable(1);
@@ -27,15 +26,11 @@ public class XRuleFeature implements SimpleFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/annotation/AlignmentFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/AlignmentFeature.java
@@ -18,16 +18,11 @@ import edu.jhu.thrax.util.Vocabulary;
 public class AlignmentFeature implements AnnotationFeature {
   
   public static final String NAME = "alignment";
-  public static final String LABEL = "Alignment";
   
   private static final IntWritable ZERO = new IntWritable(0);
 
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public AlignmentWritable score(RuleWritable r, Annotation annotation) {
@@ -35,11 +30,11 @@ public class AlignmentFeature implements AnnotationFeature {
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationPassthroughFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationPassthroughFeature.java
@@ -15,14 +15,9 @@ import edu.jhu.thrax.hadoop.jobs.ThraxJob;
 public class AnnotationPassthroughFeature implements AnnotationFeature {
   
   public static final String NAME = "annotation";
-  public static final String LABEL = "Annotation";
 
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public Annotation score(RuleWritable r, Annotation annotation) {

--- a/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationReducer.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/AnnotationReducer.java
@@ -43,7 +43,7 @@ public class AnnotationReducer extends Reducer<RuleWritable, Annotation, RuleWri
       throws IOException, InterruptedException {
     for (Annotation annotation : values) {
       for (AnnotationFeature f : annotationFeatures) {
-        context.write(key, new FeaturePair(Vocabulary.id(f.getLabel()), f.score(key, annotation)));
+        context.write(key, new FeaturePair(Vocabulary.id(f.getName()), f.score(key, annotation)));
       }
     }
   }

--- a/src/edu/jhu/thrax/hadoop/features/annotation/CountFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/CountFeature.java
@@ -16,7 +16,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class CountFeature implements AnnotationFeature {
 
   public static final String NAME = "count";
-  public static final String LABEL = "Count";
   
   private static final IntWritable ZERO = new IntWritable(0);
 
@@ -24,16 +23,12 @@ public class CountFeature implements AnnotationFeature {
     return NAME;
   }
   
-  public String getLabel() {
-    return LABEL;
-  }
-  
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/annotation/LogCountFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/LogCountFeature.java
@@ -16,7 +16,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class LogCountFeature implements AnnotationFeature {
 
   public static final String NAME = "logcount";
-  public static final String LABEL = "LogCount";
 
   private static final FloatWritable ZERO = new FloatWritable(0);
 
@@ -24,16 +23,12 @@ public class LogCountFeature implements AnnotationFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/annotation/RarityPenaltyFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/RarityPenaltyFeature.java
@@ -16,7 +16,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class RarityPenaltyFeature implements AnnotationFeature {
 
   public static final String NAME = "rarity";
-  public static final String LABEL = "RarityPenalty";
 
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
@@ -24,16 +23,12 @@ public class RarityPenaltyFeature implements AnnotationFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/annotation/SourceGivenTargetLexicalProbabilityFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/SourceGivenTargetLexicalProbabilityFeature.java
@@ -22,7 +22,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class SourceGivenTargetLexicalProbabilityFeature implements AnnotationFeature {
 
   public static final String NAME = "f_given_e_lex";
-  public static final String LABEL = "Lex(f|e)";
   
   private static final float DEFAULT_PROB = 10e-7f;
   
@@ -30,10 +29,6 @@ public class SourceGivenTargetLexicalProbabilityFeature implements AnnotationFea
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public void init(Context context) throws IOException, InterruptedException {
@@ -108,10 +103,10 @@ public class SourceGivenTargetLexicalProbabilityFeature implements AnnotationFea
   private static final FloatWritable ONE_PROB = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE_PROB);
+    map.put(Vocabulary.id(NAME), ONE_PROB);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE_PROB);
+    map.put(Vocabulary.id(NAME), ONE_PROB);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/annotation/TargetGivenSourceLexicalProbabilityFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/TargetGivenSourceLexicalProbabilityFeature.java
@@ -22,7 +22,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class TargetGivenSourceLexicalProbabilityFeature implements AnnotationFeature {
 
   public static final String NAME = "e_given_f_lex";
-  public static final String LABEL = "Lex(e|f)";
   
   private static final float DEFAULT_PROB = 10e-7f;
   
@@ -30,10 +29,6 @@ public class TargetGivenSourceLexicalProbabilityFeature implements AnnotationFea
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public void init(Context context) throws IOException, InterruptedException {
@@ -109,10 +104,10 @@ public class TargetGivenSourceLexicalProbabilityFeature implements AnnotationFea
   private static final FloatWritable ONE_PROB = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE_PROB);
+    map.put(Vocabulary.id(NAME), ONE_PROB);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ONE_PROB);
+    map.put(Vocabulary.id(NAME), ONE_PROB);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/annotation/UnalignedSourceCounterFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/UnalignedSourceCounterFeature.java
@@ -16,17 +16,12 @@ import edu.jhu.thrax.util.Vocabulary;
 @SuppressWarnings("rawtypes")
 public class UnalignedSourceCounterFeature implements AnnotationFeature {
   
-  public static final String NAME = "unaligned-source";
-  public static final String LABEL = "UnalignedSource";
+  public static final String NAME = "unaligned_source";
   
   private static final IntWritable ZERO = new IntWritable(0);
 
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public IntWritable score(RuleWritable r, Annotation annotation) {
@@ -45,11 +40,11 @@ public class UnalignedSourceCounterFeature implements AnnotationFeature {
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/annotation/UnalignedTargetCounterFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/annotation/UnalignedTargetCounterFeature.java
@@ -16,17 +16,12 @@ import edu.jhu.thrax.util.Vocabulary;
 @SuppressWarnings("rawtypes")
 public class UnalignedTargetCounterFeature implements AnnotationFeature {
 
-  public static final String NAME = "unaligned-target";
-  private static final String LABEL = "UnalignedTarget";
+  public static final String NAME = "unaligned_target";
 
   private static final IntWritable ZERO = new IntWritable(0);
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public IntWritable score(RuleWritable r, Annotation annotation) {
@@ -45,11 +40,11 @@ public class UnalignedTargetCounterFeature implements AnnotationFeature {
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   @Override

--- a/src/edu/jhu/thrax/hadoop/features/mapred/GoodTuringSmoothedSourcePhraseGivenTargetFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/GoodTuringSmoothedSourcePhraseGivenTargetFeature.java
@@ -29,14 +29,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class GoodTuringSmoothedSourcePhraseGivenTargetFeature extends MapReduceFeature {
 
   public static final String NAME = "f_given_e_phrase_gt_smoothed";
-  public static final String LABEL = "p_gt(f|e)";
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
   
   @Override
@@ -101,7 +96,7 @@ public class GoodTuringSmoothedSourcePhraseGivenTargetFeature extends MapReduceF
         prob = new FloatWritable((float) -Math.log(smoothedCount / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -109,10 +104,10 @@ public class GoodTuringSmoothedSourcePhraseGivenTargetFeature extends MapReduceF
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/GoodTuringSmoothedTargetPhraseGivenSourceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/GoodTuringSmoothedTargetPhraseGivenSourceFeature.java
@@ -29,14 +29,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class GoodTuringSmoothedTargetPhraseGivenSourceFeature extends MapReduceFeature {
 
   public static final String NAME = "e_given_f_phrase_gt_smoothed";
-  public static final String LABEL = "p_gt(e|f)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
   
   @Override
@@ -101,7 +96,7 @@ public class GoodTuringSmoothedTargetPhraseGivenSourceFeature extends MapReduceF
         prob = new FloatWritable((float) -Math.log(smoothedCount / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -109,10 +104,10 @@ public class GoodTuringSmoothedTargetPhraseGivenSourceFeature extends MapReduceF
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/LhsGivenSourcePhraseFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/LhsGivenSourcePhraseFeature.java
@@ -25,14 +25,9 @@ public class LhsGivenSourcePhraseFeature extends MapReduceFeature {
 
   
   public static final String NAME = "lhs_given_f";
-  public static final String LABEL = "p(LHS|f)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
   
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -104,7 +99,7 @@ public class LhsGivenSourcePhraseFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -145,10 +140,10 @@ public class LhsGivenSourcePhraseFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/LhsGivenTargetPhraseFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/LhsGivenTargetPhraseFeature.java
@@ -24,14 +24,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class LhsGivenTargetPhraseFeature extends MapReduceFeature {
 
   public static final String NAME = "lhs_given_e";
-  public static final String LABEL = "p(LHS|e)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
   
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -102,7 +97,7 @@ public class LhsGivenTargetPhraseFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -143,10 +138,10 @@ public class LhsGivenTargetPhraseFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenLHSFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class SourcePhraseGivenLHSFeature extends MapReduceFeature {
 
   public static final String NAME = "f_given_lhs";
-  public static final String LABEL = "p(f|LHS)";
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -100,7 +95,7 @@ public class SourcePhraseGivenLHSFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
   }
 
@@ -140,10 +135,10 @@ public class SourcePhraseGivenLHSFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenTargetFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenTargetFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class SourcePhraseGivenTargetFeature extends MapReduceFeature {
 
   public static final String NAME = "f_given_e_phrase";
-  public static final String LABEL = "p(f|e)";
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -102,7 +97,7 @@ public class SourcePhraseGivenTargetFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -143,10 +138,10 @@ public class SourcePhraseGivenTargetFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenTargetandLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/SourcePhraseGivenTargetandLHSFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class SourcePhraseGivenTargetandLHSFeature extends MapReduceFeature {
 
   public static final String NAME = "f_given_e_and_lhs";
-  public static final String LABEL = "p(f|e,LHS)";
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -89,7 +84,7 @@ public class SourcePhraseGivenTargetandLHSFeature extends MapReduceFeature {
         count += x.get();
       }
       FloatWritable prob = new FloatWritable((float) -Math.log(count / (float) marginal));
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
   }
 
@@ -138,10 +133,10 @@ public class SourcePhraseGivenTargetandLHSFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenLHSFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class TargetPhraseGivenLHSFeature extends MapReduceFeature {
 
   public static final String NAME = "e_given_lhs";
-  public static final String LABEL = "p(e|LHS)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
   
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -101,7 +96,7 @@ public class TargetPhraseGivenLHSFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -142,10 +137,10 @@ public class TargetPhraseGivenLHSFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenSourceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenSourceFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class TargetPhraseGivenSourceFeature extends MapReduceFeature {
 
   public static final String NAME = "e_given_f_phrase";
-  public static final String LABEL = "p(e|f)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
 
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -103,7 +98,7 @@ public class TargetPhraseGivenSourceFeature extends MapReduceFeature {
         prob = new FloatWritable((float) -Math.log(count / (float) marginal));
         return;
       }
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -144,10 +139,10 @@ public class TargetPhraseGivenSourceFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenSourceandLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/mapred/TargetPhraseGivenSourceandLHSFeature.java
@@ -25,14 +25,9 @@ import edu.jhu.thrax.util.Vocabulary;
 public class TargetPhraseGivenSourceandLHSFeature extends MapReduceFeature {
 
   public static final String NAME = "e_given_f_and_lhs";
-  public static final String LABEL = "p(e|f,LHS)";
   
   public String getName() {
     return NAME;
-  }
-  
-  public String getLabel() {
-    return LABEL;
   }
   
   public Class<? extends WritableComparator> sortComparatorClass() {
@@ -92,7 +87,7 @@ public class TargetPhraseGivenSourceandLHSFeature extends MapReduceFeature {
         count += x.get();
 
       FloatWritable prob = new FloatWritable((float) -Math.log(count / (float) marginal));
-      context.write(key, new FeaturePair(Vocabulary.id(LABEL), prob));
+      context.write(key, new FeaturePair(Vocabulary.id(NAME), prob));
     }
 
   }
@@ -142,10 +137,10 @@ public class TargetPhraseGivenSourceandLHSFeature extends MapReduceFeature {
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
   public void unaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, java.util.Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/pivot/NonAggregatingPivotedFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/NonAggregatingPivotedFeature.java
@@ -19,7 +19,7 @@ public abstract class NonAggregatingPivotedFeature implements PivotedFeature {
   }
 
   public void aggregate(FeatureMap features) {
-    FloatWritable val = (FloatWritable) features.get(getLabel());
+    FloatWritable val = (FloatWritable) features.get(getName());
     if (value == Float.MAX_VALUE) {
       value = val.get();
     } else {
@@ -35,10 +35,10 @@ public abstract class NonAggregatingPivotedFeature implements PivotedFeature {
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(getLabel()), ZERO);
+    map.put(Vocabulary.id(getName()), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(getLabel()), ZERO);
+    map.put(Vocabulary.id(getName()), ZERO);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedAnnotationFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedAnnotationFeature.java
@@ -15,16 +15,11 @@ import edu.jhu.thrax.hadoop.features.annotation.AnnotationPassthroughFeature;
 public class PivotedAnnotationFeature implements PivotedFeature {
 
   public static final String NAME = "annotation"; 
-  public static final String LABEL = AnnotationPassthroughFeature.LABEL;
   
   private Annotation aggregated = null;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -34,8 +29,8 @@ public class PivotedAnnotationFeature implements PivotedFeature {
   }
 
   public Annotation pivot(FeatureMap src, FeatureMap tgt) {
-    AlignmentWritable src_f2e = ((AlignmentWritable) src.get(AlignmentFeature.LABEL));
-    AlignmentWritable tgt_f2e = ((AlignmentWritable) tgt.get(AlignmentFeature.LABEL));
+    AlignmentWritable src_f2e = ((AlignmentWritable) src.get(AlignmentFeature.NAME));
+    AlignmentWritable tgt_f2e = ((AlignmentWritable) tgt.get(AlignmentFeature.NAME));
 
     return new Annotation(src_f2e.join(tgt_f2e));
   }
@@ -49,7 +44,7 @@ public class PivotedAnnotationFeature implements PivotedFeature {
   }
 
   public void aggregate(FeatureMap a) {
-    Annotation annotation = (Annotation) a.get(AnnotationPassthroughFeature.LABEL);
+    Annotation annotation = (Annotation) a.get(AnnotationPassthroughFeature.NAME);
     if (aggregated == null) {
       aggregated = new Annotation(annotation);
     } else {

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLexicalSourceGivenTargetFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLexicalSourceGivenTargetFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.annotation.TargetGivenSourceLexicalProbabil
 public class PivotedLexicalSourceGivenTargetFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = SourceGivenTargetLexicalProbabilityFeature.NAME;
-  public static final String LABEL = SourceGivenTargetLexicalProbabilityFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedLexicalSourceGivenTargetFeature extends PivotedNegLogProbFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float egf = ((FloatWritable) tgt.get(TargetGivenSourceLexicalProbabilityFeature.LABEL)).get();
-    float fge = ((FloatWritable) src.get(SourceGivenTargetLexicalProbabilityFeature.LABEL)).get();
+    float egf = ((FloatWritable) tgt.get(TargetGivenSourceLexicalProbabilityFeature.NAME)).get();
+    float fge = ((FloatWritable) src.get(SourceGivenTargetLexicalProbabilityFeature.NAME)).get();
 
     return new FloatWritable(egf + fge);
   }
@@ -39,8 +34,8 @@ public class PivotedLexicalSourceGivenTargetFeature extends PivotedNegLogProbFea
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetGivenSourceLexicalProbabilityFeature.LABEL);
-    lower_bound_labels.add(SourceGivenTargetLexicalProbabilityFeature.LABEL);
+    lower_bound_labels.add(TargetGivenSourceLexicalProbabilityFeature.NAME);
+    lower_bound_labels.add(SourceGivenTargetLexicalProbabilityFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLexicalTargetGivenSourceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLexicalTargetGivenSourceFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.annotation.TargetGivenSourceLexicalProbabil
 public class PivotedLexicalTargetGivenSourceFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = TargetGivenSourceLexicalProbabilityFeature.NAME;
-  public static final String LABEL = TargetGivenSourceLexicalProbabilityFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedLexicalTargetGivenSourceFeature extends PivotedNegLogProbFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float egf = ((FloatWritable) src.get(TargetGivenSourceLexicalProbabilityFeature.LABEL)).get();
-    float fge = ((FloatWritable) tgt.get(SourceGivenTargetLexicalProbabilityFeature.LABEL)).get();
+    float egf = ((FloatWritable) src.get(TargetGivenSourceLexicalProbabilityFeature.NAME)).get();
+    float fge = ((FloatWritable) tgt.get(SourceGivenTargetLexicalProbabilityFeature.NAME)).get();
 
     return new FloatWritable(egf + fge);
   }
@@ -39,8 +34,8 @@ public class PivotedLexicalTargetGivenSourceFeature extends PivotedNegLogProbFea
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetGivenSourceLexicalProbabilityFeature.LABEL);
-    lower_bound_labels.add(SourceGivenTargetLexicalProbabilityFeature.LABEL);
+    lower_bound_labels.add(TargetGivenSourceLexicalProbabilityFeature.NAME);
+    lower_bound_labels.add(SourceGivenTargetLexicalProbabilityFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLhsGivenSourcePhraseFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLhsGivenSourcePhraseFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.LhsGivenTargetPhraseFeature;
 public class PivotedLhsGivenSourcePhraseFeature extends NonAggregatingPivotedFeature {
 
   public static final String NAME = LhsGivenSourcePhraseFeature.NAME;
-  public static final String LABEL = LhsGivenSourcePhraseFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -29,13 +24,13 @@ public class PivotedLhsGivenSourcePhraseFeature extends NonAggregatingPivotedFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    return new FloatWritable(((FloatWritable) src.get(LhsGivenTargetPhraseFeature.LABEL)).get());
+    return new FloatWritable(((FloatWritable) src.get(LhsGivenTargetPhraseFeature.NAME)).get());
   }
 
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(LhsGivenTargetPhraseFeature.LABEL);
+    lower_bound_labels.add(LhsGivenTargetPhraseFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLhsGivenTargetPhraseFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedLhsGivenTargetPhraseFeature.java
@@ -11,14 +11,9 @@ import edu.jhu.thrax.hadoop.features.mapred.LhsGivenTargetPhraseFeature;
 public class PivotedLhsGivenTargetPhraseFeature extends NonAggregatingPivotedFeature {
 
   public static final String NAME = LhsGivenTargetPhraseFeature.NAME;
-  public static final String LABEL = LhsGivenTargetPhraseFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -28,13 +23,13 @@ public class PivotedLhsGivenTargetPhraseFeature extends NonAggregatingPivotedFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    return new FloatWritable(((FloatWritable) tgt.get(LhsGivenTargetPhraseFeature.LABEL)).get());
+    return new FloatWritable(((FloatWritable) tgt.get(LhsGivenTargetPhraseFeature.NAME)).get());
   }
 
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(LhsGivenTargetPhraseFeature.LABEL);
+    lower_bound_labels.add(LhsGivenTargetPhraseFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedNegLogProbFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedNegLogProbFeature.java
@@ -20,7 +20,7 @@ public abstract class PivotedNegLogProbFeature implements PivotedFeature {
   }
 
   public void aggregate(FeatureMap features) {
-    FloatWritable val = (FloatWritable) features.get(getLabel());
+    FloatWritable val = (FloatWritable) features.get(getName());
     aggregated = NegLogMath.logAdd(aggregated, val.get());
   }
 
@@ -29,10 +29,10 @@ public abstract class PivotedNegLogProbFeature implements PivotedFeature {
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(getLabel()), ONE_PROB);
+    map.put(Vocabulary.id(getName()), ONE_PROB);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(getLabel()), ONE_PROB);
+    map.put(Vocabulary.id(getName()), ONE_PROB);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedRarityPenaltyFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedRarityPenaltyFeature.java
@@ -14,7 +14,6 @@ import edu.jhu.thrax.util.Vocabulary;
 public class PivotedRarityPenaltyFeature implements PivotedFeature {
 
   public static final String NAME = RarityPenaltyFeature.NAME;
-  public static final String LABEL = RarityPenaltyFeature.LABEL;
 
   private static final FloatWritable ZERO = new FloatWritable(0.0f);
 
@@ -26,10 +25,6 @@ public class PivotedRarityPenaltyFeature implements PivotedFeature {
     return NAME;
   }
 
-  public String getLabel() {
-    return LABEL;
-  }
-
   public Set<String> getPrerequisites() {
     Set<String> prereqs = new HashSet<String>();
     prereqs.add(RarityPenaltyFeature.NAME);
@@ -37,17 +32,17 @@ public class PivotedRarityPenaltyFeature implements PivotedFeature {
   }
 
   public FloatWritable pivot(FeatureMap a, FeatureMap b) {
-    float a_rp = ((FloatWritable) a.get(RarityPenaltyFeature.LABEL)).get();
-    float b_rp = ((FloatWritable) b.get(RarityPenaltyFeature.LABEL)).get();
+    float a_rp = ((FloatWritable) a.get(RarityPenaltyFeature.NAME)).get();
+    float b_rp = ((FloatWritable) b.get(RarityPenaltyFeature.NAME)).get();
     return new FloatWritable(Math.max(a_rp, b_rp));
   }
 
   public void unaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void binaryGlueRuleScore(int nt, Map<Integer, Writable> map) {
-    map.put(Vocabulary.id(LABEL), ZERO);
+    map.put(Vocabulary.id(NAME), ZERO);
   }
 
   public void initializeAggregation() {
@@ -55,7 +50,7 @@ public class PivotedRarityPenaltyFeature implements PivotedFeature {
   }
 
   public void aggregate(FeatureMap a) {
-    float rp = ((FloatWritable) a.get(LABEL)).get();
+    float rp = ((FloatWritable) a.get(NAME)).get();
     if (aggregated_rp == -1) {
       aggregated_rp = rp;
     } else {
@@ -73,7 +68,7 @@ public class PivotedRarityPenaltyFeature implements PivotedFeature {
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(RarityPenaltyFeature.LABEL);
+    lower_bound_labels.add(RarityPenaltyFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenLHSFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenLHSFeature;
 public class PivotedSourcePhraseGivenLHSFeature extends NonAggregatingPivotedFeature {
 
   public static final String NAME = SourcePhraseGivenLHSFeature.NAME;
-  public static final String LABEL = SourcePhraseGivenLHSFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -29,13 +24,13 @@ public class PivotedSourcePhraseGivenLHSFeature extends NonAggregatingPivotedFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    return new FloatWritable(((FloatWritable) src.get(TargetPhraseGivenLHSFeature.LABEL)).get());
+    return new FloatWritable(((FloatWritable) src.get(TargetPhraseGivenLHSFeature.NAME)).get());
   }
 
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenLHSFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenLHSFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenTargetAndLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenTargetAndLHSFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenSourceandLHSFeature
 public class PivotedSourcePhraseGivenTargetAndLHSFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = SourcePhraseGivenTargetandLHSFeature.NAME; 
-  public static final String LABEL = SourcePhraseGivenTargetandLHSFeature.LABEL;
   
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedSourcePhraseGivenTargetAndLHSFeature extends PivotedNegLogPr
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float fge = ((FloatWritable) src.get(TargetPhraseGivenSourceandLHSFeature.LABEL)).get();
-    float egf = ((FloatWritable) tgt.get(SourcePhraseGivenTargetandLHSFeature.LABEL)).get();
+    float fge = ((FloatWritable) src.get(TargetPhraseGivenSourceandLHSFeature.NAME)).get();
+    float egf = ((FloatWritable) tgt.get(SourcePhraseGivenTargetandLHSFeature.NAME)).get();
 
     return new FloatWritable(egf + fge);
   }
@@ -39,8 +34,8 @@ public class PivotedSourcePhraseGivenTargetAndLHSFeature extends PivotedNegLogPr
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenSourceandLHSFeature.LABEL);
-    lower_bound_labels.add(SourcePhraseGivenTargetandLHSFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenSourceandLHSFeature.NAME);
+    lower_bound_labels.add(SourcePhraseGivenTargetandLHSFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenTargetFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedSourcePhraseGivenTargetFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenSourceFeature;
 public class PivotedSourcePhraseGivenTargetFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = SourcePhraseGivenTargetFeature.NAME;
-  public static final String LABEL = SourcePhraseGivenTargetFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedSourcePhraseGivenTargetFeature extends PivotedNegLogProbFeat
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float src_f = ((FloatWritable) src.get(TargetPhraseGivenSourceFeature.LABEL)).get();
-    float f_tgt = ((FloatWritable) tgt.get(SourcePhraseGivenTargetFeature.LABEL)).get();
+    float src_f = ((FloatWritable) src.get(TargetPhraseGivenSourceFeature.NAME)).get();
+    float f_tgt = ((FloatWritable) tgt.get(SourcePhraseGivenTargetFeature.NAME)).get();
 
     return new FloatWritable(src_f + f_tgt);
   }
@@ -39,8 +34,8 @@ public class PivotedSourcePhraseGivenTargetFeature extends PivotedNegLogProbFeat
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenSourceFeature.LABEL);
-    lower_bound_labels.add(SourcePhraseGivenTargetFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenSourceFeature.NAME);
+    lower_bound_labels.add(SourcePhraseGivenTargetFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenLHSFeature.java
@@ -11,14 +11,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenLHSFeature;
 public class PivotedTargetPhraseGivenLHSFeature extends NonAggregatingPivotedFeature {
 
   public static final String NAME = TargetPhraseGivenLHSFeature.NAME;
-  public static final String LABEL = TargetPhraseGivenLHSFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -28,13 +23,13 @@ public class PivotedTargetPhraseGivenLHSFeature extends NonAggregatingPivotedFea
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    return new FloatWritable(((FloatWritable) tgt.get(TargetPhraseGivenLHSFeature.LABEL)).get());
+    return new FloatWritable(((FloatWritable) tgt.get(TargetPhraseGivenLHSFeature.NAME)).get());
   }
 
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenLHSFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenLHSFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenSourceAndLHSFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenSourceAndLHSFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenSourceandLHSFeature
 public class PivotedTargetPhraseGivenSourceAndLHSFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = TargetPhraseGivenSourceandLHSFeature.NAME;
-  public static final String LABEL = TargetPhraseGivenSourceandLHSFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedTargetPhraseGivenSourceAndLHSFeature extends PivotedNegLogPr
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float fge = ((FloatWritable) tgt.get(TargetPhraseGivenSourceandLHSFeature.LABEL)).get();
-    float egf = ((FloatWritable) src.get(SourcePhraseGivenTargetandLHSFeature.LABEL)).get();
+    float fge = ((FloatWritable) tgt.get(TargetPhraseGivenSourceandLHSFeature.NAME)).get();
+    float egf = ((FloatWritable) src.get(SourcePhraseGivenTargetandLHSFeature.NAME)).get();
 
     return new FloatWritable(egf + fge);
   }
@@ -39,8 +34,8 @@ public class PivotedTargetPhraseGivenSourceAndLHSFeature extends PivotedNegLogPr
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenSourceandLHSFeature.LABEL);
-    lower_bound_labels.add(SourcePhraseGivenTargetandLHSFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenSourceandLHSFeature.NAME);
+    lower_bound_labels.add(SourcePhraseGivenTargetandLHSFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenSourceFeature.java
+++ b/src/edu/jhu/thrax/hadoop/features/pivot/PivotedTargetPhraseGivenSourceFeature.java
@@ -12,14 +12,9 @@ import edu.jhu.thrax.hadoop.features.mapred.TargetPhraseGivenSourceFeature;
 public class PivotedTargetPhraseGivenSourceFeature extends PivotedNegLogProbFeature {
 
   public static final String NAME = TargetPhraseGivenSourceFeature.NAME;
-  public static final String LABEL = TargetPhraseGivenSourceFeature.LABEL;
 
   public String getName() {
     return NAME;
-  }
-
-  public String getLabel() {
-    return LABEL;
   }
 
   public Set<String> getPrerequisites() {
@@ -30,8 +25,8 @@ public class PivotedTargetPhraseGivenSourceFeature extends PivotedNegLogProbFeat
   }
 
   public FloatWritable pivot(FeatureMap src, FeatureMap tgt) {
-    float tgt_f = ((FloatWritable) tgt.get(TargetPhraseGivenSourceFeature.LABEL)).get();
-    float f_src = ((FloatWritable) src.get(SourcePhraseGivenTargetFeature.LABEL)).get();
+    float tgt_f = ((FloatWritable) tgt.get(TargetPhraseGivenSourceFeature.NAME)).get();
+    float f_src = ((FloatWritable) src.get(SourcePhraseGivenTargetFeature.NAME)).get();
 
     return new FloatWritable(tgt_f + f_src);
   }
@@ -39,8 +34,8 @@ public class PivotedTargetPhraseGivenSourceFeature extends PivotedNegLogProbFeat
   @Override
   public Set<String> getLowerBoundLabels() {
     Set<String> lower_bound_labels = new HashSet<String>();
-    lower_bound_labels.add(TargetPhraseGivenSourceFeature.LABEL);
-    lower_bound_labels.add(SourcePhraseGivenTargetFeature.LABEL);
+    lower_bound_labels.add(TargetPhraseGivenSourceFeature.NAME);
+    lower_bound_labels.add(SourcePhraseGivenTargetFeature.NAME);
     return lower_bound_labels;
   }
 

--- a/src/edu/jhu/thrax/hadoop/output/OutputReducer.java
+++ b/src/edu/jhu/thrax/hadoop/output/OutputReducer.java
@@ -44,7 +44,7 @@ public class OutputReducer extends Reducer<RuleWritable, FeaturePair, Text, Null
     for (FeaturePair fp : values)
       features.put(Vocabulary.word(fp.key), fp.val.get());
     for (SimpleFeature feature : simpleFeatures)
-      features.put(feature.getLabel(), feature.score(key));
+      features.put(feature.getName(), feature.score(key));
     context.write(FormatUtils.ruleToText(key, features, label, sparse), NullWritable.get());
   }
 }

--- a/src/edu/jhu/thrax/hadoop/paraphrasing/AggregationCombiner.java
+++ b/src/edu/jhu/thrax/hadoop/paraphrasing/AggregationCombiner.java
@@ -63,7 +63,7 @@ public class AggregationCombiner
       }
     }
     for (PivotedFeature feature : pivotedFeatures)
-      merged.put(feature.getLabel(), feature.finalizeAggregation());
+      merged.put(feature.getName(), feature.finalizeAggregation());
     context.write(key, merged);
   }
 }

--- a/src/edu/jhu/thrax/hadoop/paraphrasing/AggregationReducer.java
+++ b/src/edu/jhu/thrax/hadoop/paraphrasing/AggregationReducer.java
@@ -85,15 +85,15 @@ public class AggregationReducer extends Reducer<RuleWritable, FeatureMap, Text, 
       }
     }
     for (PivotedFeature feature : pivotedFeatures)
-      features.put(feature.getLabel(), feature.finalizeAggregation());
+      features.put(feature.getName(), feature.finalizeAggregation());
 
     for (SimpleFeature feature : simpleFeatures)
-      features.put(feature.getLabel(), feature.score(rule));
+      features.put(feature.getName(), feature.score(rule));
 
     for (AnnotationFeature feature : annotationFeatures)
-      features.put(feature.getLabel(),
-          feature.score(rule, (Annotation) features.get(AnnotationPassthroughFeature.LABEL)));
-    features.remove(AnnotationPassthroughFeature.LABEL);
+      features.put(feature.getName(),
+          feature.score(rule, (Annotation) features.get(AnnotationPassthroughFeature.NAME)));
+    features.remove(AnnotationPassthroughFeature.NAME);
 
     context.write(FormatUtils.ruleToText(rule, features, label, sparse), NullWritable.get());
   }

--- a/src/edu/jhu/thrax/hadoop/paraphrasing/PivotingReducer.java
+++ b/src/edu/jhu/thrax/hadoop/paraphrasing/PivotingReducer.java
@@ -98,9 +98,9 @@ public class PivotingReducer extends Reducer<RuleWritable, FeatureMap, RuleWrita
       seen_first = true;
 
       Annotation annotation =
-          (Annotation) features.get(AnnotationPassthroughFeature.LABEL);
+          (Annotation) features.get(AnnotationPassthroughFeature.NAME);
       for (AnnotationFeature f : annotationFeatures)
-        features.put(f.getLabel(), f.score(key, annotation));
+        features.put(f.getName(), f.score(key, annotation));
 
       if (!prune(features, translationPruningRules))
         targets.add(new ParaphrasePattern(key.target, nts, lhs, key.monotone, features));
@@ -138,7 +138,7 @@ public class PivotingReducer extends Reducer<RuleWritable, FeatureMap, RuleWrita
     try {
       // Compute the features.
       for (PivotedFeature f : pivotedFeatures)
-        pivoted_features.put(f.getLabel(), f.pivot(src.features, tgt.features));
+        pivoted_features.put(f.getName(), f.pivot(src.features, tgt.features));
     } catch (Exception e) {
       StringBuilder src_f = new StringBuilder();
       for (int w : src.features.keySet())
@@ -177,7 +177,7 @@ public class PivotingReducer extends Reducer<RuleWritable, FeatureMap, RuleWrita
       } else {
         continue;
       }
-      int label = Vocabulary.id(PivotedFeatureFactory.get(f[0]).getLabel());
+      int label = Vocabulary.id(PivotedFeatureFactory.get(f[0]).getName());
       rules.put(label, new PruningRule(smaller, Float.parseFloat(f[1])));
     }
     return rules;

--- a/src/edu/jhu/thrax/util/FormatUtils.java
+++ b/src/edu/jhu/thrax/util/FormatUtils.java
@@ -128,7 +128,7 @@ public class FormatUtils {
     for (String t : fs.keySet()) {
       String score;
       Writable val = fs.get(t);
-      if (t.equals("Count")) {
+      if (t.toLowerCase().equals("count")) {
         ruleCount = String.format("%d", ((IntWritable) fs.get(t)).get());
         continue;
       } else if (val instanceof FloatWritable) {

--- a/src/edu/jhu/thrax/util/Vocabulary.java
+++ b/src/edu/jhu/thrax/util/Vocabulary.java
@@ -114,33 +114,33 @@ public class Vocabulary {
       String features = BackwardsCompatibility.equivalent(conf.get("thrax.features", ""));
       if ("translation".equals(type)) {
         for (MapReduceFeature f : MapReduceFeatureFactory.getAll(features))
-          id(f.getLabel());
+          id(f.getName());
       } else if ("paraphrasing".equals(type)) {
         Set<String> prereq_features = new HashSet<String>();
         for (PivotedFeature f : PivotedFeatureFactory.getAll(features)) {
           prereq_features.addAll(f.getPrerequisites());
-          id(f.getLabel());
+          id(f.getName());
         }
-        id((new PivotedAnnotationFeature()).getLabel());
+        id((new PivotedAnnotationFeature()).getName());
         for (String prereq : prereq_features) {
           MapReduceFeature mf = MapReduceFeatureFactory.get(prereq);
           if (mf != null) {
-            id(mf.getLabel());
+            id(mf.getName());
           } else {
             AnnotationFeature af = AnnotationFeatureFactory.get(prereq);
             if (af != null) {
-              id(af.getLabel());
+              id(af.getName());
             } else {
               SimpleFeature sf = SimpleFeatureFactory.get(prereq);
-              if (sf != null) id(sf.getLabel());
+              if (sf != null) id(sf.getName());
             }
           }
         }
       }
       for (AnnotationFeature f : AnnotationFeatureFactory.getAll(features))
-        id(f.getLabel());
+        id(f.getName());
       for (SimpleFeature f : SimpleFeatureFactory.getAll(features))
-        id(f.getLabel());
+        id(f.getName());
       head = size();      
       return true;
     }


### PR DESCRIPTION
This removes labels from features and uses their names instead. Avoid the confusion when specifying feature functions in thrax.config (such as "phrase-penalty") and enabled feature labeling. Before, the resulting grammar would contain labels such as PhrasePenalty=X. Now the labels in the resulting grammar correspond to the feature names given in the thrax config.

Also unified feature names a bit to use underscores throughout.