### PR TITLE
No longer delete extracted rules during the output job.

### DIFF
--- a/src/edu/jhu/thrax/hadoop/jobs/OutputJob.java
+++ b/src/edu/jhu/thrax/hadoop/jobs/OutputJob.java
@@ -74,14 +74,6 @@ public class OutputJob implements ThraxJob {
     if (FileInputFormat.getInputPaths(job).length == 0) {
       // TODO: This is going to crash.
       FileInputFormat.addInputPath(job, new Path(workDir + "rules"));
-    } else {
-      // We have at least one feature to aggregate, so we don't need
-      // the rules sub-directory at all at this point.
-      // We delete it to save disk space.
-      final FileSystem fs = FileSystem.get(conf);
-      final Path rulesPath = new Path(workDir + "rules");
-      final boolean recursive = true;
-      fs.delete(rulesPath, recursive);
     }
 
     String outputPath = conf.get("thrax.outputPath", "");


### PR DESCRIPTION
Sometimes it's nice to have the rules for debugging purposes. As one probably anyway deletes the working directory after extraction, it seemed kind of sneaky to delete the rules folder as part of the output job.